### PR TITLE
adds GitHub workflow to build and deploy to K8s

### DIFF
--- a/.github/workflows/build-deploy.js.yml
+++ b/.github/workflows/build-deploy.js.yml
@@ -1,0 +1,41 @@
+name: OctoBay APP - Test, Build, Push, Deploy
+
+on:
+  push:
+    branches: [ development ]
+  pull_request:
+    branches: [ development ]
+
+jobs:
+  build-and-push:
+    name: Build and Push Image
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Get current date
+      id: date
+      run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+    - name: Build & push docker image
+      env:
+        TAG: ${{ steps.date.outputs.date }} 
+      run: |
+        docker build -t octobay/app:$TAG .
+        echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+        docker push octobay/app:$TAG
+  
+  deploy:
+    name: Deploy to Kubernetes
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Create kubeconfig
+      run: |
+        mkdir ${HOME}/.kube
+        echo ${{ secrets.KUBE_CONFIG }} | base64 --decode > ${HOME}/.kube/config
+    - name: Use context
+      run: kubectl config use-context octobay-api
+    - name: Deploy to K8s
+      run: kubectl apply -f .k8s/

--- a/.k8s/deployment.yml
+++ b/.k8s/deployment.yml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: octobay-app
+  name: octobay-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: octobay-app
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: octobay-app
+    spec:
+      containers:
+      - image: octobay/app
+        name: app

--- a/.k8s/svc.yml
+++ b/.k8s/svc.yml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: octobay-app
+  name: octobay-app
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    app: octobay-app
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
I know we're on Vercel right now anyways, but this leaves the option open to using k8s instead if we like.

Can integrate build test and lint steps before this as well, will re-introduce all three in follow up PR.

K8s yamls in follow up PR.